### PR TITLE
Fix "Refused to execute script" error and undefined method `regexp_source` exception

### DIFF
--- a/lib/cucumber_characteristics/profile_data.rb
+++ b/lib/cucumber_characteristics/profile_data.rb
@@ -75,7 +75,9 @@ module CucumberCharacteristics
         step_profiles[step_name][:total_count] += 1
         step_profiles[step_name][s.status][:feature_location][feature_location] ||= []
         next unless s.status != :undefined
-        step_profiles[step_name][:regexp] = s.step_match.step_definition.regexp_source
+        regexp = s.step_match.step_definition.try :regexp_source
+        regexp ||= s.step_match.step_definition.try :expression
+        step_profiles[step_name][:regexp] = regexp.to_s
         if s.status == :passed
           step_profiles[step_name][s.status][:feature_location][feature_location] << s.step_match.duration
         end

--- a/lib/cucumber_characteristics/view/step_report.html.haml
+++ b/lib/cucumber_characteristics/view/step_report.html.haml
@@ -174,7 +174,7 @@
 
     %script{:src => "https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"}
     %script{:src => "http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"}
-    %script{:src => "https://raw.githubusercontent.com/christianbach/tablesorter/master/jquery.tablesorter.min.js"}
+    %script{:src => "https://cdn.rawgit.com/christianbach/tablesorter/master/jquery.tablesorter.min.js"}
     :javascript
       $(document).ready(function()
       {


### PR DESCRIPTION
Chrome did show this js error:
Refused to execute script from 'https://raw.githubusercontent.com/christianbach/tablesorter/master/jquery.tablesorter.min.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
Fixed it by switching to cdn.rawgit.com.